### PR TITLE
feat: add project pages with Apollo GraphQL

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@apollo/client": "^4.0.3",
         "axios": "^1.11.0",
+        "graphql": "^16.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2",
@@ -58,6 +60,48 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.3.tgz",
+      "integrity": "sha512-XCrNpBwVymRLEUbMjiP4WGmeNnP9bRhqX7ZqlEvZRAkYFvLPQyI65/ldAFvyfTnI4vjRLgpkwGKqW2+BelPEiw==",
+      "license": "MIT",
+      "workspaces": [
+        "dist",
+        "codegen",
+        "scripts/codemods/ac3-to-ac4"
+      ],
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "optimism": "^0.18.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -936,6 +980,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2391,6 +2444,54 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3389,6 +3490,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4081,6 +4206,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4422,6 +4559,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -4625,6 +4772,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@apollo/client": "^4.0.3",
     "axios": "^1.11.0",
+    "graphql": "^16.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,9 @@ import Login from './pages/Login';
 import ResetPasswordRequest from './pages/ResetPasswordRequest';
 import ResetPasswordConfirm from './pages/ResetPasswordConfirm';
 import Logout from './pages/Logout';
+import ProjectsList from './pages/projects/ProjectsList';
+import ProjectDetail from './pages/projects/ProjectDetail';
+import CreateProject from './pages/projects/CreateProject';
 
 export default function App() {
   return (
@@ -14,6 +17,9 @@ export default function App() {
         <Route path="/reset-password" element={<ResetPasswordRequest />} />
         <Route path="/reset-password/confirm" element={<ResetPasswordConfirm />} />
         <Route path="/logout" element={<Logout />} />
+        <Route path="/projects" element={<ProjectsList />} />
+        <Route path="/projects/new" element={<CreateProject />} />
+        <Route path="/projects/:id" element={<ProjectDetail />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/api/projectsApi.ts
+++ b/frontend/src/api/projectsApi.ts
@@ -1,0 +1,79 @@
+import { ApolloClient, InMemoryCache, createHttpLink, gql } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+import { useAuthStore } from '../store/authStore';
+
+const httpLink = createHttpLink({
+  uri: 'http://localhost:8000/graphql',
+});
+
+const authLink = setContext((_, { headers }) => {
+  const token = useAuthStore.getState().accessToken;
+  return {
+    headers: {
+      ...headers,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  };
+});
+
+export const client = new ApolloClient({
+  link: authLink.concat(httpLink),
+  cache: new InMemoryCache(),
+});
+
+export const LIST_PROJECTS = gql`
+  query ListProjects {
+    projects {
+      id
+      title
+      budgetMin
+      budgetMax
+      status
+    }
+  }
+`;
+
+export const GET_PROJECT = gql`
+  query GetProject($id: Int!) {
+    project(id: $id) {
+      id
+      title
+      description
+      owner {
+        id
+        username
+      }
+      budgetMin
+      budgetMax
+      status
+    }
+  }
+`;
+
+export const CREATE_PROJECT = gql`
+  mutation CreateProject($title: String!, $description: String!, $budgetMin: Float, $budgetMax: Float) {
+    createProject(title: $title, description: $description, budgetMin: $budgetMin, budgetMax: $budgetMax) {
+      id
+      title
+    }
+  }
+`;
+
+export const UPDATE_PROJECT = gql`
+  mutation UpdateProject($id: Int!, $title: String, $description: String, $budgetMin: Float, $budgetMax: Float, $status: String) {
+    updateProject(id: $id, title: $title, description: $description, budgetMin: $budgetMin, budgetMax: $budgetMax, status: $status) {
+      id
+      title
+      description
+      budgetMin
+      budgetMax
+      status
+    }
+  }
+`;
+
+export const DELETE_PROJECT = gql`
+  mutation DeleteProject($id: Int!) {
+    deleteProject(id: $id)
+  }
+`;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { ApolloProvider } from '@apollo/client';
 import App from './App.tsx';
 import './styles/globals.css';
+import { client } from './api/projectsApi';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/projects/CreateProject.tsx
+++ b/frontend/src/pages/projects/CreateProject.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { CREATE_PROJECT } from '../../api/projectsApi';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../../store/authStore';
+
+export default function CreateProject() {
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    budgetMin: '',
+    budgetMax: '',
+  });
+  const navigate = useNavigate();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const [createProject] = useMutation(CREATE_PROJECT);
+
+  if (!accessToken) {
+    return <div>Необходимо войти для создания проекта</div>;
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await createProject({
+      variables: {
+        title: form.title,
+        description: form.description,
+        budgetMin: form.budgetMin ? parseFloat(form.budgetMin) : null,
+        budgetMax: form.budgetMax ? parseFloat(form.budgetMax) : null,
+      },
+    });
+    navigate('/projects');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        name="title"
+        value={form.title}
+        onChange={handleChange}
+        placeholder="Title"
+        className="border p-2 w-full"
+      />
+      <textarea
+        name="description"
+        value={form.description}
+        onChange={handleChange}
+        placeholder="Description"
+        className="border p-2 w-full"
+      />
+      <input
+        name="budgetMin"
+        value={form.budgetMin}
+        onChange={handleChange}
+        placeholder="Budget Min"
+        className="border p-2 w-full"
+      />
+      <input
+        name="budgetMax"
+        value={form.budgetMax}
+        onChange={handleChange}
+        placeholder="Budget Max"
+        className="border p-2 w-full"
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Create
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/projects/ProjectDetail.tsx
+++ b/frontend/src/pages/projects/ProjectDetail.tsx
@@ -1,0 +1,27 @@
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { GET_PROJECT } from '../../api/projectsApi';
+
+export default function ProjectDetail() {
+  const { id } = useParams();
+  const { data, loading } = useQuery(GET_PROJECT, {
+    variables: { id: Number(id) },
+  });
+
+  if (loading) return <div>Loading...</div>;
+  const project = data?.project;
+
+  if (!project) return <div>Project not found</div>;
+
+  return (
+    <div className="space-y-2">
+      <h1 className="text-xl font-bold">{project.title}</h1>
+      <p>{project.description}</p>
+      <p>Owner: {project.owner.username}</p>
+      <p>
+        Budget: {project.budgetMin} - {project.budgetMax}
+      </p>
+      <p>Status: {project.status}</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/projects/ProjectsList.tsx
+++ b/frontend/src/pages/projects/ProjectsList.tsx
@@ -1,0 +1,42 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { LIST_PROJECTS } from '../../api/projectsApi';
+
+interface Project {
+  id: number;
+  title: string;
+  budgetMin: number | null;
+  budgetMax: number | null;
+  status: string;
+}
+
+export default function ProjectsList() {
+  const navigate = useNavigate();
+  const { data, loading } = useQuery(LIST_PROJECTS);
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-4">
+      <button
+        className="bg-blue-500 text-white px-4 py-2"
+        onClick={() => navigate('/projects/new')}
+      >
+        Создать проект
+      </button>
+      <ul className="space-y-2">
+        {data?.projects?.map((project: Project) => (
+          <li key={project.id} className="border p-2">
+            <Link to={`/projects/${project.id}`} className="font-bold">
+              {project.title}
+            </Link>
+            <div>
+              Budget: {project.budgetMin} - {project.budgetMax}
+            </div>
+            <div>Status: {project.status}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- configure Apollo Client with auth header and project queries
- add project list, detail, and creation pages
- wire project routes and wrap app with Apollo provider

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60e40b86083229112e5a03a10f078