### PR TITLE
feat: add project bids management

### DIFF
--- a/frontend/src/api/bidsApi.ts
+++ b/frontend/src/api/bidsApi.ts
@@ -1,0 +1,93 @@
+import { gql } from '@apollo/client';
+import { client } from './projectsApi';
+
+interface Bid {
+  id: number;
+  amount: number;
+  message: string;
+  status: string;
+  freelancer: {
+    id: number;
+    username: string;
+  };
+}
+
+export const LIST_BIDS = gql`
+  query ListBids($projectId: Int!) {
+    bids(projectId: $projectId) {
+      id
+      amount
+      message
+      status
+      freelancer {
+        id
+        username
+      }
+    }
+  }
+`;
+
+export const CREATE_BID = gql`
+  mutation CreateBid($projectId: Int!, $amount: Float!, $message: String!) {
+    createBid(projectId: $projectId, amount: $amount, message: $message) {
+      id
+      amount
+      message
+      status
+      freelancer {
+        id
+        username
+      }
+    }
+  }
+`;
+
+export const ACCEPT_BID = gql`
+  mutation AcceptBid($id: Int!) {
+    acceptBid(id: $id) {
+      id
+      status
+    }
+  }
+`;
+
+export const REJECT_BID = gql`
+  mutation RejectBid($id: Int!) {
+    rejectBid(id: $id) {
+      id
+      status
+    }
+  }
+`;
+
+export const bidsApi = {
+  listBids: async (projectId: number) => {
+    const { data } = await client.query<{ bids: Bid[] }>({
+      query: LIST_BIDS,
+      variables: { projectId },
+    });
+    return data!.bids;
+  },
+  createBid: async (projectId: number, amount: number, message: string) => {
+    const { data } = await client.mutate<{ createBid: Bid }>({
+      mutation: CREATE_BID,
+      variables: { projectId, amount, message },
+    });
+    return data!.createBid;
+  },
+  acceptBid: async (id: number) => {
+    const { data } = await client.mutate<{ acceptBid: Bid }>({
+      mutation: ACCEPT_BID,
+      variables: { id },
+    });
+    return data!.acceptBid;
+  },
+  rejectBid: async (id: number) => {
+    const { data } = await client.mutate<{ rejectBid: Bid }>({
+      mutation: REJECT_BID,
+      variables: { id },
+    });
+    return data!.rejectBid;
+  },
+};
+

--- a/frontend/src/pages/projects/ProjectDetail.tsx
+++ b/frontend/src/pages/projects/ProjectDetail.tsx
@@ -1,20 +1,100 @@
+import { useState } from 'react';
+import type { ChangeEvent, FormEvent } from 'react';
 import { useParams } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
+import { useQuery, useMutation } from '@apollo/client';
 import { GET_PROJECT } from '../../api/projectsApi';
+import {
+  LIST_BIDS,
+  CREATE_BID,
+  ACCEPT_BID,
+  REJECT_BID,
+} from '../../api/bidsApi';
+import { useAuthStore } from '../../store/authStore';
+
+interface Bid {
+  id: number;
+  amount: number;
+  message: string;
+  status: string;
+  freelancer: {
+    id: number;
+    username: string;
+  };
+}
 
 export default function ProjectDetail() {
   const { id } = useParams();
-  const { data, loading } = useQuery(GET_PROJECT, {
-    variables: { id: Number(id) },
+  const projectId = Number(id);
+  const token = useAuthStore((state) => state.accessToken);
+
+  let currentUserId: number | null = null;
+  if (token) {
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      currentUserId = payload.user_id;
+    } catch {
+      currentUserId = null;
+    }
+  }
+
+  const {
+    data: projectData,
+    loading: projectLoading,
+  } = useQuery(GET_PROJECT, {
+    variables: { id: projectId },
   });
 
-  if (loading) return <div>Loading...</div>;
-  const project = data?.project;
+  const project = projectData?.project;
+  const isOwner = project?.owner?.id === currentUserId;
 
+  const {
+    data: bidsData,
+    refetch: refetchBids,
+  } = useQuery(LIST_BIDS, {
+    variables: { projectId },
+    skip: !isOwner,
+  });
+
+  const [acceptBidMutation] = useMutation(ACCEPT_BID);
+  const [rejectBidMutation] = useMutation(REJECT_BID);
+  const [createBidMutation] = useMutation(CREATE_BID);
+
+  const [form, setForm] = useState({ amount: '', message: '' });
+
+  if (projectLoading) return <div>Loading...</div>;
   if (!project) return <div>Project not found</div>;
 
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleBidSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await createBidMutation({
+      variables: {
+        projectId,
+        amount: parseFloat(form.amount),
+        message: form.message,
+      },
+    });
+    setForm({ amount: '', message: '' });
+  };
+
+  const handleAccept = async (bidId: number) => {
+    await acceptBidMutation({ variables: { id: bidId } });
+    refetchBids();
+  };
+
+  const handleReject = async (bidId: number) => {
+    await rejectBidMutation({ variables: { id: bidId } });
+    refetchBids();
+  };
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-4">
       <h1 className="text-xl font-bold">{project.title}</h1>
       <p>{project.description}</p>
       <p>Owner: {project.owner.username}</p>
@@ -22,6 +102,67 @@ export default function ProjectDetail() {
         Budget: {project.budgetMin} - {project.budgetMax}
       </p>
       <p>Status: {project.status}</p>
+
+      {isOwner ? (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold mt-4">Bids</h2>
+          {bidsData?.bids?.map((bid: Bid) => (
+            <div key={bid.id} className="border p-2 space-y-1">
+              <p>
+                <span className="font-semibold">
+                  {bid.freelancer.username}
+                </span>{' '}
+                offered {bid.amount}
+              </p>
+              <p>{bid.message}</p>
+              <p>Status: {bid.status}</p>
+              {bid.status === 'pending' && (
+                <div className="space-x-2">
+                  <button
+                    className="px-2 py-1 bg-green-500 text-white"
+                    onClick={() => handleAccept(bid.id)}
+                  >
+                    Accept
+                  </button>
+                  <button
+                    className="px-2 py-1 bg-red-500 text-white"
+                    onClick={() => handleReject(bid.id)}
+                  >
+                    Reject
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <form
+          onSubmit={handleBidSubmit}
+          className="space-y-2 mt-4"
+        >
+          <h2 className="text-lg font-semibold">Leave a Bid</h2>
+          <input
+            name="amount"
+            value={form.amount}
+            onChange={handleChange}
+            placeholder="Amount"
+            className="border p-2 w-full"
+          />
+          <textarea
+            name="message"
+            value={form.message}
+            onChange={handleChange}
+            placeholder="Message"
+            className="border p-2 w-full"
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white px-4 py-2"
+          >
+            Submit Bid
+          </button>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add GraphQL API client for project bids
- allow project owners to accept or reject bids
- allow freelancers to submit bids from project detail page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Module '@apollo/client' has no exported member 'ApolloProvider')*


------
https://chatgpt.com/codex/tasks/task_e_68b756b1207883228f6be9e5be119928