### PR TITLE
Refactor authentication and permissions across app

### DIFF
--- a/backend/config/schema.py
+++ b/backend/config/schema.py
@@ -1,0 +1,19 @@
+import strawberry
+import projects.schema
+import bids.schema
+import reviews.schema
+
+
+@strawberry.type
+class Query(projects.schema.Query, bids.schema.Query, reviews.schema.Query):
+    pass
+
+
+@strawberry.type
+class Mutation(
+    projects.schema.Mutation, bids.schema.Mutation, reviews.schema.Mutation
+):
+    pass
+
+
+schema = strawberry.Schema(query=Query, mutation=Mutation)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Logout from './pages/Logout';
 import ProjectsList from './pages/projects/ProjectsList';
 import ProjectDetail from './pages/projects/ProjectDetail';
 import CreateProject from './pages/projects/CreateProject';
+import PrivateRoute from './components/PrivateRoute';
 
 export default function App() {
   return (
@@ -16,9 +17,23 @@ export default function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/reset-password" element={<ResetPasswordRequest />} />
         <Route path="/reset-password/confirm" element={<ResetPasswordConfirm />} />
-        <Route path="/logout" element={<Logout />} />
+        <Route
+          path="/logout"
+          element={
+            <PrivateRoute>
+              <Logout />
+            </PrivateRoute>
+          }
+        />
         <Route path="/projects" element={<ProjectsList />} />
-        <Route path="/projects/new" element={<CreateProject />} />
+        <Route
+          path="/projects/new"
+          element={
+            <PrivateRoute>
+              <CreateProject />
+            </PrivateRoute>
+          }
+        />
         <Route path="/projects/:id" element={<ProjectDetail />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -1,26 +1,65 @@
 import axios from 'axios';
+import { useAuthStore } from '../store/authStore';
 
-const API_URL = '/api/auth';
+const api = axios.create({ baseURL: '/api/auth' });
+
+api.interceptors.request.use((config) => {
+  const token = useAuthStore.getState().accessToken;
+  if (token) {
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${token}`,
+    };
+  }
+  return config;
+});
 
 export const authApi = {
-  register: async ({ username, email, phone, password }: { username: string; email: string; phone: string; password: string; }) => {
-    const response = await axios.post(`${API_URL}/register/`, { username, email, phone, password });
+  register: async ({
+    username,
+    email,
+    phone,
+    password,
+  }: {
+    username: string;
+    email: string;
+    phone: string;
+    password: string;
+  }) => {
+    const response = await api.post('/register/', {
+      username,
+      email,
+      phone,
+      password,
+    });
     return response.data;
   },
-  login: async ({ identifier, password }: { identifier: string; password: string; }) => {
-    const response = await axios.post(`${API_URL}/login/`, { identifier, password });
+  login: async ({ identifier, password }: { identifier: string; password: string }) => {
+    const response = await api.post('/login/', { identifier, password });
     return response.data;
   },
   logout: async (refreshToken: string) => {
-    const response = await axios.post(`${API_URL}/logout/`, { refresh: refreshToken });
+    const response = await api.post('/logout/', { refresh: refreshToken });
     return response.data;
   },
   requestPasswordReset: async (identifier: string) => {
-    const response = await axios.post(`${API_URL}/password-reset/request/`, { identifier });
+    const response = await api.post('/password-reset/request/', { identifier });
     return response.data;
   },
-  confirmPasswordReset: async ({ identifier, code, new_password }: { identifier: string; code: string; new_password: string; }) => {
-    const response = await axios.post(`${API_URL}/password-reset/confirm/`, { identifier, code, new_password });
+  confirmPasswordReset: async ({
+    identifier,
+    code,
+    new_password,
+  }: {
+    identifier: string;
+    code: string;
+    new_password: string;
+  }) => {
+    const response = await api.post('/password-reset/confirm/', {
+      identifier,
+      code,
+      new_password,
+    });
     return response.data;
   },
 };

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { useAuthStore } from '../store/authStore';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function PrivateRoute({ children }: Props) {
+  const token = useAuthStore((state) => state.accessToken);
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/components/Reviews.tsx
+++ b/frontend/src/components/Reviews.tsx
@@ -14,6 +14,7 @@ export default function Reviews({ userId, projectId, canReview }: ReviewsProps) 
   const [createReview] = useMutation(CREATE_REVIEW);
 
   const [form, setForm] = useState({ rating: 5, comment: '' });
+  const [error, setError] = useState('');
 
   const handleChange = (
     e: ChangeEvent<HTMLSelectElement | HTMLTextAreaElement>,
@@ -25,15 +26,20 @@ export default function Reviews({ userId, projectId, canReview }: ReviewsProps) 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!projectId) return;
-    await createReview({
-      variables: {
-        projectId,
-        rating: Number(form.rating),
-        comment: form.comment,
-      },
-    });
-    setForm({ rating: 5, comment: '' });
-    refetch();
+    try {
+      await createReview({
+        variables: {
+          projectId,
+          rating: Number(form.rating),
+          comment: form.comment,
+        },
+      });
+      setForm({ rating: 5, comment: '' });
+      setError('');
+      refetch();
+    } catch {
+      setError('Failed to submit review');
+    }
   };
 
   return (
@@ -59,6 +65,7 @@ export default function Reviews({ userId, projectId, canReview }: ReviewsProps) 
             placeholder="Comment"
             className="border p-2 w-full"
           />
+          {error && <div className="text-red-500">{error}</div>}
           <button type="submit" className="bg-blue-500 text-white px-4 py-2">
             Submit Review
           </button>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -5,6 +5,8 @@ import { useAuthStore } from '../store/authStore';
 export default function Login() {
   const [form, setForm] = useState({ identifier: '', password: '', rememberMe: false });
   const login = useAuthStore((state) => state.login);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value, type, checked } = e.target;
@@ -13,8 +15,17 @@ export default function Login() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const data = await authApi.login({ identifier: form.identifier, password: form.password });
-    login({ accessToken: data.access, refreshToken: data.refresh });
+    try {
+      setLoading(true);
+      const data = await authApi.login({ identifier: form.identifier, password: form.password });
+      login({ accessToken: data.access, refreshToken: data.refresh });
+    } catch (err: unknown) {
+      const resp = err as { response?: { data?: { detail?: string } } };
+      const message = resp.response?.data?.detail ?? 'Login failed';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -43,8 +54,9 @@ export default function Login() {
         />
         <span>Remember me</span>
       </label>
-      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
-        Login
+      {error && <div className="text-red-500">{error}</div>}
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2" disabled={loading}>
+        {loading ? 'Loading...' : 'Login'}
       </button>
     </form>
   );

--- a/frontend/src/pages/Logout.tsx
+++ b/frontend/src/pages/Logout.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { authApi } from '../api/authApi';
 import { useAuthStore } from '../store/authStore';
 
 export default function Logout() {
   const refreshToken = useAuthStore((state) => state.refreshToken);
   const logoutStore = useAuthStore((state) => state.logout);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const doLogout = async () => {
@@ -12,9 +14,10 @@ export default function Logout() {
         await authApi.logout(refreshToken);
       }
       logoutStore();
+      navigate('/login');
     };
     void doLogout();
-  }, [refreshToken, logoutStore]);
+  }, [refreshToken, logoutStore, navigate]);
 
   return <div>Logging out...</div>;
 }

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -3,6 +3,8 @@ import { authApi } from '../api/authApi';
 
 export default function Register() {
   const [form, setForm] = useState({ username: '', email: '', phone: '', password: '' });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -10,7 +12,15 @@ export default function Register() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await authApi.register(form);
+    try {
+      setLoading(true);
+      await authApi.register(form);
+      alert('Registration successful');
+    } catch {
+      setError('Registration failed');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -44,8 +54,9 @@ export default function Register() {
         placeholder="Password"
         className="border p-2 w-full"
       />
-      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
-        Register
+      {error && <div className="text-red-500">{error}</div>}
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2" disabled={loading}>
+        {loading ? 'Loading...' : 'Register'}
       </button>
     </form>
   );

--- a/frontend/src/pages/ResetPasswordConfirm.tsx
+++ b/frontend/src/pages/ResetPasswordConfirm.tsx
@@ -3,6 +3,8 @@ import { authApi } from '../api/authApi';
 
 export default function ResetPasswordConfirm() {
   const [form, setForm] = useState({ identifier: '', code: '', new_password: '' });
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -10,7 +12,14 @@ export default function ResetPasswordConfirm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await authApi.confirmPasswordReset(form);
+    try {
+      await authApi.confirmPasswordReset(form);
+      setMessage('Password reset successful');
+      setError('');
+    } catch {
+      setError('Reset failed');
+      setMessage('');
+    }
   };
 
   return (
@@ -37,6 +46,8 @@ export default function ResetPasswordConfirm() {
         placeholder="New Password"
         className="border p-2 w-full"
       />
+      {message && <div className="text-green-600">{message}</div>}
+      {error && <div className="text-red-500">{error}</div>}
       <button type="submit" className="bg-blue-500 text-white px-4 py-2">
         Reset Password
       </button>

--- a/frontend/src/pages/ResetPasswordRequest.tsx
+++ b/frontend/src/pages/ResetPasswordRequest.tsx
@@ -3,10 +3,19 @@ import { authApi } from '../api/authApi';
 
 export default function ResetPasswordRequest() {
   const [identifier, setIdentifier] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await authApi.requestPasswordReset(identifier);
+    try {
+      await authApi.requestPasswordReset(identifier);
+      setMessage('Reset code sent');
+      setError('');
+    } catch {
+      setError('Request failed');
+      setMessage('');
+    }
   };
 
   return (
@@ -17,6 +26,8 @@ export default function ResetPasswordRequest() {
         placeholder="Email or Phone"
         className="border p-2 w-full"
       />
+      {message && <div className="text-green-600">{message}</div>}
+      {error && <div className="text-red-500">{error}</div>}
       <button type="submit" className="bg-blue-500 text-white px-4 py-2">
         Request Reset
       </button>

--- a/frontend/src/pages/projects/CreateProject.tsx
+++ b/frontend/src/pages/projects/CreateProject.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { CREATE_PROJECT } from '../../api/projectsApi';
 import { useNavigate } from 'react-router-dom';
-import { useAuthStore } from '../../store/authStore';
 
 export default function CreateProject() {
   const [form, setForm] = useState({
@@ -12,12 +11,8 @@ export default function CreateProject() {
     budgetMax: '',
   });
   const navigate = useNavigate();
-  const accessToken = useAuthStore((state) => state.accessToken);
   const [createProject] = useMutation(CREATE_PROJECT);
-
-  if (!accessToken) {
-    return <div>Необходимо войти для создания проекта</div>;
-  }
+  const [error, setError] = useState('');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -26,15 +21,19 @@ export default function CreateProject() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await createProject({
-      variables: {
-        title: form.title,
-        description: form.description,
-        budgetMin: form.budgetMin ? parseFloat(form.budgetMin) : null,
-        budgetMax: form.budgetMax ? parseFloat(form.budgetMax) : null,
-      },
-    });
-    navigate('/projects');
+    try {
+      await createProject({
+        variables: {
+          title: form.title,
+          description: form.description,
+          budgetMin: form.budgetMin ? parseFloat(form.budgetMin) : null,
+          budgetMax: form.budgetMax ? parseFloat(form.budgetMax) : null,
+        },
+      });
+      navigate('/projects');
+    } catch {
+      setError('Failed to create project');
+    }
   };
 
   return (
@@ -67,6 +66,7 @@ export default function CreateProject() {
         placeholder="Budget Max"
         className="border p-2 w-full"
       />
+      {error && <div className="text-red-500">{error}</div>}
       <button type="submit" className="bg-blue-500 text-white px-4 py-2">
         Create
       </button>

--- a/frontend/src/pages/projects/ProjectsList.tsx
+++ b/frontend/src/pages/projects/ProjectsList.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { LIST_PROJECTS } from '../../api/projectsApi';
+import { useAuthStore } from '../../store/authStore';
 
 interface Project {
   id: number;
@@ -13,17 +14,20 @@ interface Project {
 export default function ProjectsList() {
   const navigate = useNavigate();
   const { data, loading } = useQuery(LIST_PROJECTS);
+  const token = useAuthStore((state) => state.accessToken);
 
   if (loading) return <div>Loading...</div>;
 
   return (
     <div className="space-y-4">
-      <button
-        className="bg-blue-500 text-white px-4 py-2"
-        onClick={() => navigate('/projects/new')}
-      >
-        Создать проект
-      </button>
+      {token && (
+        <button
+          className="bg-blue-500 text-white px-4 py-2"
+          onClick={() => navigate('/projects/new')}
+        >
+          Создать проект
+        </button>
+      )}
       <ul className="space-y-2">
         {data?.projects?.map((project: Project) => (
           <li key={project.id} className="border p-2">

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -10,15 +10,26 @@ interface AuthState {
   refreshToken: string | null;
   login: (tokens: Tokens) => void;
   logout: () => void;
-  setTokens: (tokens: Tokens) => void;
-  clearTokens: () => void;
 }
 
+const storedAccess = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
+const storedRefresh = typeof window !== 'undefined' ? localStorage.getItem('refreshToken') : null;
+
 export const useAuthStore = create<AuthState>((set) => ({
-  accessToken: null,
-  refreshToken: null,
-  login: (tokens) => set({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken }),
-  logout: () => set({ accessToken: null, refreshToken: null }),
-  setTokens: (tokens) => set({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken }),
-  clearTokens: () => set({ accessToken: null, refreshToken: null }),
+  accessToken: storedAccess,
+  refreshToken: storedRefresh,
+  login: ({ accessToken, refreshToken }) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+    }
+    set({ accessToken, refreshToken });
+  },
+  logout: () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+    }
+    set({ accessToken: null, refreshToken: null });
+  },
 }));


### PR DESCRIPTION
## Summary
- unify password reset flow using identifier and add email/phone delivery
- enforce bid access permissions and add global schema wiring
- add auth-aware API client, token store, private routes and improved UI feedback

## Testing
- `python manage.py test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7657f312883228e6a0e20e3331bce