### PR TITLE
feat: add wallet and payments pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,9 @@ import ProjectsList from './pages/projects/ProjectsList';
 import ProjectDetail from './pages/projects/ProjectDetail';
 import CreateProject from './pages/projects/CreateProject';
 import PrivateRoute from './components/PrivateRoute';
+import Wallet from './pages/payments/Wallet';
+import Transactions from './pages/payments/Transactions';
+import Transfer from './pages/payments/Transfer';
 
 export default function App() {
   return (
@@ -22,6 +25,30 @@ export default function App() {
           element={
             <PrivateRoute>
               <Logout />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/wallet"
+          element={
+            <PrivateRoute>
+              <Wallet />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/wallet/transactions"
+          element={
+            <PrivateRoute>
+              <Transactions />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/wallet/transfer"
+          element={
+            <PrivateRoute>
+              <Transfer />
             </PrivateRoute>
           }
         />

--- a/frontend/src/api/paymentsApi.ts
+++ b/frontend/src/api/paymentsApi.ts
@@ -1,0 +1,100 @@
+import { gql } from '@apollo/client';
+import { client } from './projectsApi';
+
+export interface Wallet {
+  id: number;
+  balance: number;
+}
+
+export interface Transaction {
+  id: number;
+  amount: number;
+  type: string;
+  status: string;
+  createdAt: string;
+}
+
+export const GET_WALLET = gql`
+  query GetWallet {
+    wallet {
+      id
+      balance
+    }
+  }
+`;
+
+export const LIST_TRANSACTIONS = gql`
+  query ListTransactions {
+    transactions {
+      id
+      type
+      amount
+      status
+      createdAt
+    }
+  }
+`;
+
+export const DEPOSIT = gql`
+  mutation Deposit($amount: Float!) {
+    deposit(amount: $amount) {
+      id
+      balance
+    }
+  }
+`;
+
+export const WITHDRAW = gql`
+  mutation Withdraw($amount: Float!) {
+    withdraw(amount: $amount) {
+      id
+      balance
+    }
+  }
+`;
+
+export const TRANSFER = gql`
+  mutation Transfer($toUserId: Int!, $amount: Float!) {
+    transfer(toUserId: $toUserId, amount: $amount) {
+      id
+      balance
+    }
+  }
+`;
+
+export const paymentsApi = {
+  getWallet: async () => {
+    const { data } = await client.query<{ wallet: Wallet }>({
+      query: GET_WALLET,
+    });
+    return data!.wallet;
+  },
+  getTransactions: async () => {
+    const { data } = await client.query<{ transactions: Transaction[] }>({
+      query: LIST_TRANSACTIONS,
+    });
+    return data!.transactions;
+  },
+  deposit: async (amount: number) => {
+    const { data } = await client.mutate<{ deposit: Wallet }>({
+      mutation: DEPOSIT,
+      variables: { amount },
+    });
+    return data!.deposit;
+  },
+  withdraw: async (amount: number) => {
+    const { data } = await client.mutate<{ withdraw: Wallet }>({
+      mutation: WITHDRAW,
+      variables: { amount },
+    });
+    return data!.withdraw;
+  },
+  transfer: async (toUserId: number, amount: number) => {
+    const { data } = await client.mutate<{ transfer: Wallet }>({
+      mutation: TRANSFER,
+      variables: { toUserId, amount },
+    });
+    return data!.transfer;
+  },
+};
+

--- a/frontend/src/pages/payments/Transactions.tsx
+++ b/frontend/src/pages/payments/Transactions.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { paymentsApi, type Transaction } from '../../api/paymentsApi';
+
+export default function Transactions() {
+  const [items, setItems] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    paymentsApi
+      .getTransactions()
+      .then((t) => setItems(t))
+      .catch(() => setError('Failed to load transactions'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">{error}</div>;
+
+  return (
+    <table className="w-full border">
+      <thead>
+        <tr>
+          <th className="border px-2">Тип</th>
+          <th className="border px-2">Сумма</th>
+          <th className="border px-2">Статус</th>
+          <th className="border px-2">Дата</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((t) => (
+          <tr key={t.id}>
+            <td className="border px-2">{t.type}</td>
+            <td className="border px-2">{t.amount}</td>
+            <td className="border px-2">{t.status}</td>
+            <td className="border px-2">{new Date(t.createdAt).toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/frontend/src/pages/payments/Transfer.tsx
+++ b/frontend/src/pages/payments/Transfer.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { paymentsApi } from '../../api/paymentsApi';
+
+export default function Transfer() {
+  const [form, setForm] = useState({ toUserId: '', amount: '' });
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await paymentsApi.transfer(Number(form.toUserId), parseFloat(form.amount));
+      setSuccess('Перевод выполнен');
+      setError('');
+      setForm({ toUserId: '', amount: '' });
+    } catch {
+      setError('Transfer failed');
+      setSuccess('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        name="toUserId"
+        value={form.toUserId}
+        onChange={handleChange}
+        placeholder="ID пользователя"
+        className="border p-2 w-full"
+      />
+      <input
+        name="amount"
+        value={form.amount}
+        onChange={handleChange}
+        placeholder="Сумма"
+        className="border p-2 w-full"
+      />
+      {error && <div className="text-red-500">{error}</div>}
+      {success && <div className="text-green-500">{success}</div>}
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Отправить
+      </button>
+    </form>
+  );
+}
+

--- a/frontend/src/pages/payments/Wallet.tsx
+++ b/frontend/src/pages/payments/Wallet.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { paymentsApi, type Wallet as WalletType } from '../../api/paymentsApi';
+
+export default function Wallet() {
+  const [wallet, setWallet] = useState<WalletType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    paymentsApi
+      .getWallet()
+      .then((w) => setWallet(w))
+      .catch(() => setError('Failed to load wallet'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleDeposit = async () => {
+    const amountStr = prompt('Введите сумму для пополнения:');
+    const amount = parseFloat(amountStr || '');
+    if (!amount) return;
+    const updated = await paymentsApi.deposit(amount);
+    setWallet(updated);
+  };
+
+  const handleWithdraw = async () => {
+    const amountStr = prompt('Введите сумму для вывода:');
+    const amount = parseFloat(amountStr || '');
+    if (!amount) return;
+    const updated = await paymentsApi.withdraw(amount);
+    setWallet(updated);
+  };
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">{error}</div>;
+
+  return (
+    <div className="space-y-4">
+      <div>Баланс: {wallet?.balance}</div>
+      <div className="space-x-2">
+        <button className="bg-green-500 text-white px-4 py-2" onClick={handleDeposit}>
+          Пополнить
+        </button>
+        <button className="bg-yellow-500 text-white px-4 py-2" onClick={handleWithdraw}>
+          Вывести
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add GraphQL payments API for wallet, transactions and transfers
- create wallet, transactions and transfer pages
- wire wallet routes into app routing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: TypeScript compile errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7739b214c8322ad667a432bdfd189