### PR TITLE
feat: add chat frontend with websocket

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,8 @@ import PrivateRoute from './components/PrivateRoute';
 import Wallet from './pages/payments/Wallet';
 import Transactions from './pages/payments/Transactions';
 import Transfer from './pages/payments/Transfer';
+import ChatList from './pages/chat/ChatList';
+import ChatRoom from './pages/chat/ChatRoom';
 
 export default function App() {
   return (
@@ -49,6 +51,22 @@ export default function App() {
           element={
             <PrivateRoute>
               <Transfer />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/chat"
+          element={
+            <PrivateRoute>
+              <ChatList />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/chat/:roomId"
+          element={
+            <PrivateRoute>
+              <ChatRoom />
             </PrivateRoute>
           }
         />

--- a/frontend/src/api/chatApi.ts
+++ b/frontend/src/api/chatApi.ts
@@ -1,0 +1,107 @@
+import { gql } from '@apollo/client';
+import { client } from './projectsApi';
+
+export interface Room {
+  id: number;
+  project?: { id: number; title: string } | null;
+  participants: { id: number; username: string }[];
+  createdAt: string;
+}
+
+export interface Message {
+  id: number;
+  room: { id: number };
+  author: { id: number; username: string };
+  content: string;
+  createdAt: string;
+}
+
+export const LIST_ROOMS = gql`
+  query ListRooms {
+    rooms {
+      id
+      project {
+        id
+        title
+      }
+      participants {
+        id
+        username
+      }
+      createdAt
+    }
+  }
+`;
+
+export const LIST_MESSAGES = gql`
+  query ListMessages($roomId: Int!) {
+    messages(roomId: $roomId) {
+      id
+      room {
+        id
+      }
+      author {
+        id
+        username
+      }
+      content
+      createdAt
+    }
+  }
+`;
+
+export const CREATE_ROOM = gql`
+  mutation CreateRoom($projectId: Int, $participants: [Int!]!) {
+    createRoom(projectId: $projectId, participants: $participants) {
+      id
+    }
+  }
+`;
+
+export const SEND_MESSAGE = gql`
+  mutation SendMessage($roomId: Int!, $content: String!) {
+    sendMessage(roomId: $roomId, content: $content) {
+      id
+      room {
+        id
+      }
+      author {
+        id
+        username
+      }
+      content
+      createdAt
+    }
+  }
+`;
+
+export const chatApi = {
+  listRooms: async () => {
+    const { data } = await client.query<{ rooms: Room[] }>({
+      query: LIST_ROOMS,
+    });
+    return data!.rooms;
+  },
+  listMessages: async (roomId: number) => {
+    const { data } = await client.query<{ messages: Message[] }>({
+      query: LIST_MESSAGES,
+      variables: { roomId },
+    });
+    return data!.messages;
+  },
+  createRoom: async (projectId: number | null, participants: number[]) => {
+    const { data } = await client.mutate<{ createRoom: Room }>({
+      mutation: CREATE_ROOM,
+      variables: { projectId, participants },
+    });
+    return data!.createRoom;
+  },
+  sendMessage: async (roomId: number, content: string) => {
+    const { data } = await client.mutate<{ sendMessage: Message }>({
+      mutation: SEND_MESSAGE,
+      variables: { roomId, content },
+    });
+    return data!.sendMessage;
+  },
+};
+

--- a/frontend/src/api/wsClient.ts
+++ b/frontend/src/api/wsClient.ts
@@ -1,0 +1,28 @@
+import { useChatStore } from '../store/chatStore';
+
+class ChatWSClient {
+  private socket: WebSocket | null = null;
+
+  connect(roomId: number) {
+    this.socket = new WebSocket(`ws://localhost:8000/ws/chat/${roomId}/`);
+    this.socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        useChatStore.getState().addMessage(data);
+      } catch {
+        // ignore parse errors
+      }
+    };
+  }
+
+  disconnect() {
+    this.socket?.close();
+    this.socket = null;
+  }
+
+  sendMessage(content: string) {
+    this.socket?.send(JSON.stringify({ content }));
+  }
+}
+
+export const wsClient = new ChatWSClient();

--- a/frontend/src/pages/chat/ChatList.tsx
+++ b/frontend/src/pages/chat/ChatList.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { LIST_ROOMS, Room } from '../../api/chatApi';
+
+export default function ChatList() {
+  const { data, loading } = useQuery<{ rooms: Room[] }>(LIST_ROOMS);
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2 className="text-xl mb-4">Чаты</h2>
+      <ul className="space-y-2">
+        {data?.rooms?.map((room) => (
+          <li key={room.id} className="border p-2">
+            <Link to={`/chat/${room.id}`}>Комната {room.id}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/chat/ChatRoom.tsx
+++ b/frontend/src/pages/chat/ChatRoom.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { LIST_MESSAGES, Message } from '../../api/chatApi';
+import { wsClient } from '../../api/wsClient';
+import { useChatStore } from '../../store/chatStore';
+
+export default function ChatRoom() {
+  const { roomId } = useParams();
+  const numericId = Number(roomId);
+  const { data, loading } = useQuery<{ messages: Message[] }>(LIST_MESSAGES, {
+    variables: { roomId: numericId },
+    skip: !roomId,
+  });
+  const messages = useChatStore((state) => state.messages);
+  const setMessages = useChatStore((state) => state.setMessages);
+  const setActiveRoom = useChatStore((state) => state.setActiveRoom);
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    if (data?.messages) {
+      setMessages(data.messages);
+    }
+  }, [data, setMessages]);
+
+  useEffect(() => {
+    if (!numericId) return;
+    setActiveRoom(numericId);
+    wsClient.connect(numericId);
+    return () => {
+      wsClient.disconnect();
+    };
+  }, [numericId, setActiveRoom]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!content.trim()) return;
+    wsClient.sendMessage(content);
+    setContent('');
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        {messages.map((m) => (
+          <div key={m.id} className="border p-2">
+            <strong>{m.author.username}:</strong> {m.content}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="flex space-x-2">
+        <input
+          className="flex-1 border p-2"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4" type="submit">
+          Отправить
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+export interface ChatMessage {
+  id: number;
+  room: { id: number };
+  author: { id: number; username: string };
+  content: string;
+  createdAt: string;
+}
+
+interface ChatState {
+  activeRoomId: number | null;
+  messages: ChatMessage[];
+  setActiveRoom: (id: number | null) => void;
+  setMessages: (msgs: ChatMessage[]) => void;
+  addMessage: (msg: ChatMessage) => void;
+}
+
+export const useChatStore = create<ChatState>((set) => ({
+  activeRoomId: null,
+  messages: [],
+  setActiveRoom: (id) => set({ activeRoomId: id, messages: [] }),
+  setMessages: (msgs) => set({ messages: msgs }),
+  addMessage: (msg) =>
+    set((state) => ({ messages: [...state.messages, msg] })),
+}));


### PR DESCRIPTION
## Summary
- add GraphQL chat API helper with room/message queries and mutations
- implement WebSocket client and Zustand store for live chat
- create ChatList and ChatRoom pages and wire up routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7c7b5c8248322bf3c7d9b6af33a09