### PR TITLE
feat: add admin dashboard pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,11 @@ import Transfer from './pages/payments/Transfer';
 import ChatList from './pages/chat/ChatList';
 import ChatRoom from './pages/chat/ChatRoom';
 import NotificationsList from './components/NotificationsList';
+import UsersAdmin from './pages/admin/UsersAdmin';
+import ProjectsAdmin from './pages/admin/ProjectsAdmin';
+import BidsAdmin from './pages/admin/BidsAdmin';
+import ReviewsAdmin from './pages/admin/ReviewsAdmin';
+import TransactionsAdmin from './pages/admin/TransactionsAdmin';
 import { useNotificationsStore } from './store/notificationsStore';
 import { useAuthStore } from './store/authStore';
 
@@ -133,6 +138,46 @@ export default function App() {
           element={
             <PrivateRoute>
               <NotificationsList />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/admin/users"
+          element={
+            <PrivateRoute>
+              <UsersAdmin />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/admin/projects"
+          element={
+            <PrivateRoute>
+              <ProjectsAdmin />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/admin/bids"
+          element={
+            <PrivateRoute>
+              <BidsAdmin />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/admin/reviews"
+          element={
+            <PrivateRoute>
+              <ReviewsAdmin />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/admin/transactions"
+          element={
+            <PrivateRoute>
+              <TransactionsAdmin />
             </PrivateRoute>
           }
         />

--- a/frontend/src/api/adminApi.ts
+++ b/frontend/src/api/adminApi.ts
@@ -1,0 +1,158 @@
+import { gql } from '@apollo/client';
+import { client } from './projectsApi';
+
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  isActive: boolean;
+}
+
+export interface Project {
+  id: number;
+  title: string;
+  status: string;
+}
+
+export interface Bid {
+  id: number;
+  amount: number;
+  status: string;
+}
+
+export interface Review {
+  id: number;
+  rating: number;
+  comment: string;
+}
+
+export interface Transaction {
+  id: number;
+  amount: number;
+  type: string;
+}
+
+const GET_ALL_USERS = gql`
+  query GetAllUsers {
+    allUsers {
+      id
+      username
+      email
+      role
+      isActive
+    }
+  }
+`;
+
+const BAN_USER = gql`
+  mutation BanUser($userId: Int!) {
+    banUser(userId: $userId)
+  }
+`;
+
+const GET_ALL_PROJECTS = gql`
+  query GetAllProjects {
+    allProjects {
+      id
+      title
+      status
+    }
+  }
+`;
+
+const GET_ALL_BIDS = gql`
+  query GetAllBids {
+    allBids {
+      id
+      amount
+      status
+    }
+  }
+`;
+
+const RESOLVE_DISPUTE = gql`
+  mutation ResolveDispute($bidId: Int!) {
+    resolveDispute(bidId: $bidId)
+  }
+`;
+
+const GET_ALL_REVIEWS = gql`
+  query GetAllReviews {
+    allReviews {
+      id
+      rating
+      comment
+    }
+  }
+`;
+
+const DELETE_REVIEW = gql`
+  mutation DeleteReview($reviewId: Int!) {
+    deleteReview(reviewId: $reviewId)
+  }
+`;
+
+const GET_ALL_TRANSACTIONS = gql`
+  query GetAllTransactions {
+    allTransactions {
+      id
+      amount
+      type
+    }
+  }
+`;
+
+export const adminApi = {
+  getAllUsers: async (): Promise<User[]> => {
+    const { data } = await client.query<{ allUsers: User[] }>({
+      query: GET_ALL_USERS,
+    });
+    return data!.allUsers;
+  },
+  banUser: async (userId: number): Promise<boolean> => {
+    const { data } = await client.mutate<{ banUser: boolean }>({
+      mutation: BAN_USER,
+      variables: { userId },
+    });
+    return data!.banUser;
+  },
+  getAllProjects: async (): Promise<Project[]> => {
+    const { data } = await client.query<{ allProjects: Project[] }>({
+      query: GET_ALL_PROJECTS,
+    });
+    return data!.allProjects;
+  },
+  getAllBids: async (): Promise<Bid[]> => {
+    const { data } = await client.query<{ allBids: Bid[] }>({
+      query: GET_ALL_BIDS,
+    });
+    return data!.allBids;
+  },
+  resolveDispute: async (bidId: number): Promise<boolean> => {
+    const { data } = await client.mutate<{ resolveDispute: boolean }>({
+      mutation: RESOLVE_DISPUTE,
+      variables: { bidId },
+    });
+    return data!.resolveDispute;
+  },
+  getAllReviews: async (): Promise<Review[]> => {
+    const { data } = await client.query<{ allReviews: Review[] }>({
+      query: GET_ALL_REVIEWS,
+    });
+    return data!.allReviews;
+  },
+  deleteReview: async (reviewId: number): Promise<boolean> => {
+    const { data } = await client.mutate<{ deleteReview: boolean }>({
+      mutation: DELETE_REVIEW,
+      variables: { reviewId },
+    });
+    return data!.deleteReview;
+  },
+  getAllTransactions: async (): Promise<Transaction[]> => {
+    const { data } = await client.query<{ allTransactions: Transaction[] }>({
+      query: GET_ALL_TRANSACTIONS,
+    });
+    return data!.allTransactions;
+  },
+};

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -18,7 +18,7 @@ export default function Login() {
     try {
       setLoading(true);
       const data = await authApi.login({ identifier: form.identifier, password: form.password });
-      login({ accessToken: data.access, refreshToken: data.refresh });
+      login({ accessToken: data.access, refreshToken: data.refresh, role: data.role });
     } catch (err: unknown) {
       const resp = err as { response?: { data?: { detail?: string } } };
       const message = resp.response?.data?.detail ?? 'Login failed';

--- a/frontend/src/pages/admin/BidsAdmin.tsx
+++ b/frontend/src/pages/admin/BidsAdmin.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { adminApi } from '../../api/adminApi';
+import type { Bid } from '../../api/adminApi';
+import { useAuthStore } from '../../store/authStore';
+
+export default function BidsAdmin() {
+  const [bids, setBids] = useState<Bid[]>([]);
+  const navigate = useNavigate();
+  const role = useAuthStore((state) => state.role);
+
+  useEffect(() => {
+    if (role !== 'admin') {
+      navigate('/');
+      return;
+    }
+    adminApi.getAllBids().then(setBids);
+  }, [role, navigate]);
+
+  const handleResolve = async (id: number) => {
+    await adminApi.resolveDispute(id);
+    setBids((prev) => prev.map((b) => (b.id === id ? { ...b, status: 'resolved' } : b)));
+  };
+
+  return (
+    <table className="min-w-full border">
+      <thead>
+        <tr>
+          <th className="border px-2">ID</th>
+          <th className="border px-2">Amount</th>
+          <th className="border px-2">Status</th>
+          <th className="border px-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {bids.map((b) => (
+          <tr key={b.id}>
+            <td className="border px-2">{b.id}</td>
+            <td className="border px-2">{b.amount}</td>
+            <td className="border px-2">{b.status}</td>
+            <td className="border px-2">
+              <button
+                onClick={() => handleResolve(b.id)}
+                className="bg-green-500 text-white px-2 py-1"
+              >
+                Resolve dispute
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/pages/admin/ProjectsAdmin.tsx
+++ b/frontend/src/pages/admin/ProjectsAdmin.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { adminApi } from '../../api/adminApi';
+import type { Project } from '../../api/adminApi';
+import { useAuthStore } from '../../store/authStore';
+
+export default function ProjectsAdmin() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const navigate = useNavigate();
+  const role = useAuthStore((state) => state.role);
+
+  useEffect(() => {
+    if (role !== 'admin') {
+      navigate('/');
+      return;
+    }
+    adminApi.getAllProjects().then(setProjects);
+  }, [role, navigate]);
+
+  return (
+    <table className="min-w-full border">
+      <thead>
+        <tr>
+          <th className="border px-2">ID</th>
+          <th className="border px-2">Title</th>
+          <th className="border px-2">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {projects.map((p) => (
+          <tr key={p.id}>
+            <td className="border px-2">{p.id}</td>
+            <td className="border px-2">{p.title}</td>
+            <td className="border px-2">{p.status}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/pages/admin/ReviewsAdmin.tsx
+++ b/frontend/src/pages/admin/ReviewsAdmin.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { adminApi } from '../../api/adminApi';
+import type { Review } from '../../api/adminApi';
+import { useAuthStore } from '../../store/authStore';
+
+export default function ReviewsAdmin() {
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const navigate = useNavigate();
+  const role = useAuthStore((state) => state.role);
+
+  useEffect(() => {
+    if (role !== 'admin') {
+      navigate('/');
+      return;
+    }
+    adminApi.getAllReviews().then(setReviews);
+  }, [role, navigate]);
+
+  const handleDelete = async (id: number) => {
+    await adminApi.deleteReview(id);
+    setReviews((prev) => prev.filter((r) => r.id !== id));
+  };
+
+  return (
+    <table className="min-w-full border">
+      <thead>
+        <tr>
+          <th className="border px-2">ID</th>
+          <th className="border px-2">Rating</th>
+          <th className="border px-2">Comment</th>
+          <th className="border px-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {reviews.map((r) => (
+          <tr key={r.id}>
+            <td className="border px-2">{r.id}</td>
+            <td className="border px-2">{r.rating}</td>
+            <td className="border px-2">{r.comment}</td>
+            <td className="border px-2">
+              <button
+                onClick={() => handleDelete(r.id)}
+                className="bg-red-500 text-white px-2 py-1"
+              >
+                Удалить
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/pages/admin/TransactionsAdmin.tsx
+++ b/frontend/src/pages/admin/TransactionsAdmin.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { adminApi } from '../../api/adminApi';
+import type { Transaction } from '../../api/adminApi';
+import { useAuthStore } from '../../store/authStore';
+
+export default function TransactionsAdmin() {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const navigate = useNavigate();
+  const role = useAuthStore((state) => state.role);
+
+  useEffect(() => {
+    if (role !== 'admin') {
+      navigate('/');
+      return;
+    }
+    adminApi.getAllTransactions().then(setTransactions);
+  }, [role, navigate]);
+
+  return (
+    <table className="min-w-full border">
+      <thead>
+        <tr>
+          <th className="border px-2">ID</th>
+          <th className="border px-2">Amount</th>
+          <th className="border px-2">Type</th>
+        </tr>
+      </thead>
+      <tbody>
+        {transactions.map((t) => (
+          <tr key={t.id}>
+            <td className="border px-2">{t.id}</td>
+            <td className="border px-2">{t.amount}</td>
+            <td className="border px-2">{t.type}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/pages/admin/UsersAdmin.tsx
+++ b/frontend/src/pages/admin/UsersAdmin.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { adminApi } from '../../api/adminApi';
+import type { User } from '../../api/adminApi';
+import { useAuthStore } from '../../store/authStore';
+
+export default function UsersAdmin() {
+  const [users, setUsers] = useState<User[]>([]);
+  const navigate = useNavigate();
+  const role = useAuthStore((state) => state.role);
+
+  useEffect(() => {
+    if (role !== 'admin') {
+      navigate('/');
+      return;
+    }
+    adminApi.getAllUsers().then(setUsers);
+  }, [role, navigate]);
+
+  const handleBan = async (id: number) => {
+    await adminApi.banUser(id);
+    setUsers((prev) => prev.filter((u) => u.id !== id));
+  };
+
+  return (
+    <table className="min-w-full border">
+      <thead>
+        <tr>
+          <th className="border px-2">ID</th>
+          <th className="border px-2">Username</th>
+          <th className="border px-2">Email</th>
+          <th className="border px-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {users.map((user) => (
+          <tr key={user.id}>
+            <td className="border px-2">{user.id}</td>
+            <td className="border px-2">{user.username}</td>
+            <td className="border px-2">{user.email}</td>
+            <td className="border px-2">
+              {user.isActive && (
+                <button
+                  onClick={() => handleBan(user.id)}
+                  className="bg-red-500 text-white px-2 py-1"
+                >
+                  Забанить
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -3,33 +3,41 @@ import { create } from 'zustand';
 interface Tokens {
   accessToken: string;
   refreshToken: string;
+  role?: string;
 }
 
 interface AuthState {
   accessToken: string | null;
   refreshToken: string | null;
+  role: string | null;
   login: (tokens: Tokens) => void;
   logout: () => void;
 }
 
 const storedAccess = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
 const storedRefresh = typeof window !== 'undefined' ? localStorage.getItem('refreshToken') : null;
+const storedRole = typeof window !== 'undefined' ? localStorage.getItem('role') : null;
 
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: storedAccess,
   refreshToken: storedRefresh,
-  login: ({ accessToken, refreshToken }) => {
+  role: storedRole,
+  login: ({ accessToken, refreshToken, role }) => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
+      if (role) {
+        localStorage.setItem('role', role);
+      }
     }
-    set({ accessToken, refreshToken });
+    set({ accessToken, refreshToken, role: role ?? null });
   },
   logout: () => {
     if (typeof window !== 'undefined') {
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
+      localStorage.removeItem('role');
     }
-    set({ accessToken: null, refreshToken: null });
+    set({ accessToken: null, refreshToken: null, role: null });
   },
 }));


### PR DESCRIPTION
## Summary
- add admin API for users, projects, bids, reviews, transactions
- add admin management pages and routes
- extend auth store with role-based access and support login role

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: TypeScript errors in existing code)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7cdee582483229a92fcfb91ba89cc