### PR TITLE
feat: integrate payment gateway UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import PrivateRoute from './components/PrivateRoute';
 import Wallet from './pages/payments/Wallet';
 import Transactions from './pages/payments/Transactions';
 import Transfer from './pages/payments/Transfer';
+import Deposit from './pages/payments/Deposit';
+import Withdraw from './pages/payments/Withdraw';
 import ChatList from './pages/chat/ChatList';
 import ChatRoom from './pages/chat/ChatRoom';
 import NotificationsList from './components/NotificationsList';
@@ -96,6 +98,22 @@ export default function App() {
           element={
             <PrivateRoute>
               <Transactions />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/wallet/deposit"
+          element={
+            <PrivateRoute>
+              <Deposit />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/wallet/withdraw"
+          element={
+            <PrivateRoute>
+              <Withdraw />
             </PrivateRoute>
           }
         />

--- a/frontend/src/api/paymentGatewayApi.ts
+++ b/frontend/src/api/paymentGatewayApi.ts
@@ -1,0 +1,65 @@
+import { gql } from '@apollo/client';
+import { client } from './projectsApi';
+
+export interface PaymentGatewayTransaction {
+  id: number;
+  provider: string;
+  amount: number;
+  status: string;
+  providerTxnId: string | null;
+  createdAt: string;
+}
+
+const INITIATE_PAYMENT = gql`
+  mutation InitiatePayment($provider: String!, $amount: Float!) {
+    initiatePayment(provider: $provider, amount: $amount)
+  }
+`;
+
+const LIST_PAYMENT_TRANSACTIONS = gql`
+  query PaymentTransactions {
+    paymentTransactions {
+      id
+      provider
+      amount
+      status
+      providerTxnId
+      createdAt
+    }
+  }
+`;
+
+const WITHDRAW = gql`
+  mutation Withdraw($amount: Float!) {
+    withdraw(amount: $amount) {
+      id
+      balance
+    }
+  }
+`;
+
+export const paymentGatewayApi = {
+  initiatePayment: async (provider: string, amount: number) => {
+    const { data } = await client.mutate<{ initiatePayment: string }>({
+      mutation: INITIATE_PAYMENT,
+      variables: { provider, amount },
+    });
+    return data!.initiatePayment;
+  },
+  getPaymentTransactions: async () => {
+    const { data } = await client.query<{ paymentTransactions: PaymentGatewayTransaction[] }>({
+      query: LIST_PAYMENT_TRANSACTIONS,
+      fetchPolicy: 'no-cache',
+    });
+    return data!.paymentTransactions;
+  },
+  withdraw: async (amount: number) => {
+    const { data } = await client.mutate({
+      mutation: WITHDRAW,
+      variables: { amount },
+    });
+    return data!.withdraw;
+  },
+};
+
+export type { PaymentGatewayTransaction as PaymentGatewayTransactionType };

--- a/frontend/src/pages/payments/Deposit.tsx
+++ b/frontend/src/pages/payments/Deposit.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { paymentGatewayApi } from '../../api/paymentGatewayApi';
+
+export default function Deposit() {
+  const [amount, setAmount] = useState('');
+  const [provider, setProvider] = useState('click');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const value = parseFloat(amount);
+    if (!value) return;
+    setLoading(true);
+    paymentGatewayApi
+      .initiatePayment(provider, value)
+      .then((url) => {
+        alert('Redirecting to payment provider...');
+        window.location.href = url;
+      })
+      .catch(() => {
+        alert('Failed to initiate payment');
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block">Amount</label>
+        <input
+          type="number"
+          className="border p-2 w-full"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block">Provider</label>
+        <select
+          className="border p-2 w-full"
+          value={provider}
+          onChange={(e) => setProvider(e.target.value)}
+        >
+          <option value="click">Click</option>
+          <option value="payme">Payme</option>
+          <option value="stripe">Stripe</option>
+        </select>
+      </div>
+      <button
+        type="submit"
+        className="bg-green-500 text-white px-4 py-2"
+        disabled={loading}
+      >
+        {loading ? 'Processing...' : 'Pay'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/payments/Transactions.tsx
+++ b/frontend/src/pages/payments/Transactions.tsx
@@ -1,15 +1,25 @@
 import { useEffect, useState } from 'react';
 import { paymentsApi, type Transaction } from '../../api/paymentsApi';
+import {
+  paymentGatewayApi,
+  type PaymentGatewayTransactionType,
+} from '../../api/paymentGatewayApi';
 
 export default function Transactions() {
   const [items, setItems] = useState<Transaction[]>([]);
+  const [gatewayItems, setGatewayItems] = useState<PaymentGatewayTransactionType[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
   useEffect(() => {
-    paymentsApi
-      .getTransactions()
-      .then((t) => setItems(t))
+    Promise.all([
+      paymentsApi.getTransactions(),
+      paymentGatewayApi.getPaymentTransactions(),
+    ])
+      .then(([t, pg]) => {
+        setItems(t);
+        setGatewayItems(pg);
+      })
       .catch(() => setError('Failed to load transactions'))
       .finally(() => setLoading(false));
   }, []);
@@ -18,26 +28,48 @@ export default function Transactions() {
   if (error) return <div className="text-red-500">{error}</div>;
 
   return (
-    <table className="w-full border">
-      <thead>
-        <tr>
-          <th className="border px-2">Тип</th>
-          <th className="border px-2">Сумма</th>
-          <th className="border px-2">Статус</th>
-          <th className="border px-2">Дата</th>
-        </tr>
-      </thead>
-      <tbody>
-        {items.map((t) => (
-          <tr key={t.id}>
-            <td className="border px-2">{t.type}</td>
-            <td className="border px-2">{t.amount}</td>
-            <td className="border px-2">{t.status}</td>
-            <td className="border px-2">{new Date(t.createdAt).toLocaleString()}</td>
+    <div className="space-y-8">
+      <table className="w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2">Тип</th>
+            <th className="border px-2">Сумма</th>
+            <th className="border px-2">Статус</th>
+            <th className="border px-2">Дата</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {items.map((t) => (
+            <tr key={t.id}>
+              <td className="border px-2">{t.type}</td>
+              <td className="border px-2">{t.amount}</td>
+              <td className="border px-2">{t.status}</td>
+              <td className="border px-2">{new Date(t.createdAt).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <table className="w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2">Провайдер</th>
+            <th className="border px-2">Сумма</th>
+            <th className="border px-2">Статус</th>
+            <th className="border px-2">Дата</th>
+          </tr>
+        </thead>
+        <tbody>
+          {gatewayItems.map((t) => (
+            <tr key={t.id}>
+              <td className="border px-2">{t.provider}</td>
+              <td className="border px-2">{t.amount}</td>
+              <td className="border px-2">{t.status}</td>
+              <td className="border px-2">{new Date(t.createdAt).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
-

--- a/frontend/src/pages/payments/Withdraw.tsx
+++ b/frontend/src/pages/payments/Withdraw.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { paymentGatewayApi } from '../../api/paymentGatewayApi';
+
+export default function Withdraw() {
+  const [amount, setAmount] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const value = parseFloat(amount);
+    if (!value) return;
+    setLoading(true);
+    paymentGatewayApi
+      .withdraw(value)
+      .then(() => {
+        alert('Withdrawal successful');
+      })
+      .catch(() => {
+        alert('Withdrawal failed');
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block">Amount</label>
+        <input
+          type="number"
+          className="border p-2 w-full"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+      </div>
+      <button
+        type="submit"
+        className="bg-yellow-500 text-white px-4 py-2"
+        disabled={loading}
+      >
+        {loading ? 'Processing...' : 'Withdraw'}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add payment gateway API for initiating payments and listing provider transactions
- create deposit and withdraw pages with provider selection and redirects
- show payment gateway transactions alongside wallet history and expose new routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7d31b81488322a0084b554ab90f36